### PR TITLE
Add config option for installing dev dependencies to testenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ deps =
 commands = ...
 ```
 
+Alternatively, to quickly install all Poetry dev-dependencies to a Tox environment, add the
+`install_dev_deps =  true` option to the environment configuration. This option can be used either
+with the `require_locked_deps = true` option or without it
+
 **Note:** Regardless of the settings outlined above, all dependencies of the project package (the
 one Tox is testing) will always be installed from the lockfile.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tox-poetry-installer"
-version = "0.3.1"
+version = "0.4.0"
 license = "MIT"
 authors = ["Ethan Paul <24588726+enpaul@users.noreply.github.com>"]
 description = "Tox plugin to install Tox environment dependencies using the Poetry backend and lockfile"

--- a/tox_poetry_installer.py
+++ b/tox_poetry_installer.py
@@ -232,6 +232,23 @@ def _install_env_dependencies(
             reporter.error(f"{_REPORTER_PREFIX} {err}")
             raise err
 
+    if venv.envconfig.install_dev_deps:
+        reporter.verbosity1(
+            f"{_REPORTER_PREFIX} env specifies 'install_env_deps = true', including Poetry dev dependencies"
+        )
+
+        dev_dependencies = [
+            dep
+            for dep in poetry.locker.locked_repository(True).packages
+            if dep not in poetry.locker.locked_repository(False).packages
+        ]
+
+        reporter.verbosity1(
+            f"{_REPORTER_PREFIX} identified {len(dev_dependencies)} Poetry dev dependencies"
+        )
+
+        dependencies = list(set(dev_dependencies + dependencies))
+
     reporter.verbosity1(
         f"{_REPORTER_PREFIX} identified {len(dependencies)} total dependencies from {len(env_deps.locked_deps)} locked env dependencies"
     )
@@ -305,6 +322,13 @@ def tox_addoption(parser: ToxParser):
     Adds the ``require_locked_deps`` configuration option to the venv to check whether all
     dependencies should be treated as locked or not.
     """
+
+    parser.add_testenv_attribute(
+        name="install_dev_deps",
+        type="bool",
+        default=False,
+        help="Automatically install all Poetry development dependencies to the environment",
+    )
 
     parser.add_testenv_attribute(
         name="require_locked_deps",

--- a/tox_poetry_installer.py
+++ b/tox_poetry_installer.py
@@ -45,7 +45,7 @@ from tox.venv import VirtualEnv as ToxVirtualEnv
 
 __title__ = "tox-poetry-installer"
 __summary__ = "Tox plugin to install Tox environment dependencies using the Poetry backend and lockfile"
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 __url__ = "https://github.com/enpaul/tox-poetry-installer/"
 __license__ = "MIT"
 __authors__ = ["Ethan Paul <24588726+enpaul@users.noreply.github.com>"]


### PR DESCRIPTION
* Add testenv option `install_dev_deps` for easily installing all Poetry development dependences to a test environment
  * Can be used in conjunction with the `require_locked_deps` option and/or additional environment dependencies.

Fixes #14 