### PR TITLE
Update config handling to support tox's native env change detection

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ isolated_build = true
 [testenv]
 description = Run the tests
 require_locked_deps = true
-deps =
+locked_deps =
     pytest
     pytest-cov
     toml
@@ -18,7 +18,7 @@ basepython = python3.8
 platform = linux
 ignore_errors = true
 require_locked_deps = true
-deps =
+locked_deps =
     pylint
     mypy
     black
@@ -46,7 +46,7 @@ basepython = python3.8
 platform = linux
 ingore_errors = true
 require_locked_deps = true
-deps =
+locked_deps =
     pylint
     mypy
     black
@@ -69,7 +69,7 @@ basepython = python3.8
 platform = linux
 ingore_errors = true
 require_locked_deps = true
-deps =
+locked_deps =
     bandit
     safety
     poetry

--- a/tox_poetry_installer/constants.py
+++ b/tox_poetry_installer/constants.py
@@ -17,10 +17,3 @@ PEP508_VERSION_DELIMITERS: Tuple[str, ...] = ("~=", "==", "!=", ">", "<")
 # Prefix all reporter messages should include to indicate that they came from this module in the
 # console output.
 REPORTER_PREFIX = f"[{__about__.__title__}]:"
-
-# Suffix that indicates an env dependency should be treated as a locked dependency and thus be
-# installed from the lockfile. Will be automatically stripped off of a dependency name during
-# sorting so that the resulting string is just the valid package name. This becomes optional when
-# the "require_locked_deps" option is true for an environment; in that case a bare dependency like
-# 'foo' is treated the same as an explicitly locked dependency like 'foo@poetry'
-MAGIC_SUFFIX_MARKER = "@poetry"

--- a/tox_poetry_installer/datatypes.py
+++ b/tox_poetry_installer/datatypes.py
@@ -1,18 +1,8 @@
 """Definitions for typehints/containers used by the plugin"""
 from typing import Dict
-from typing import List
-from typing import NamedTuple
 
 from poetry.core.packages import Package as PoetryPackage
-from tox.config import DepConfig as ToxDepConfig
 
 
 # Map of package names to the package object
 PackageMap = Dict[str, PoetryPackage]
-
-
-class SortedEnvDeps(NamedTuple):
-    """Container for the two types of environment dependencies"""
-
-    unlocked_deps: List[ToxDepConfig]
-    locked_deps: List[ToxDepConfig]

--- a/tox_poetry_installer/exceptions.py
+++ b/tox_poetry_installer/exceptions.py
@@ -26,3 +26,7 @@ class LockedDepNotFoundError(ToxPoetryInstallerException):
 
 class ExtraNotFoundError(ToxPoetryInstallerException):
     """Project package extra not defined in project's pyproject.toml"""
+
+
+class LockedDepsRequiredError(ToxPoetryInstallerException):
+    """Environment cannot specify unlocked dependencies when locked dependencies are required"""

--- a/tox_poetry_installer/utilities.py
+++ b/tox_poetry_installer/utilities.py
@@ -15,58 +15,6 @@ from tox.venv import VirtualEnv as ToxVirtualEnv
 from tox_poetry_installer import constants
 from tox_poetry_installer import exceptions
 from tox_poetry_installer.datatypes import PackageMap
-from tox_poetry_installer.datatypes import SortedEnvDeps
-
-
-def sort_env_deps(venv: ToxVirtualEnv) -> SortedEnvDeps:
-    """Sorts the environment dependencies by lock status
-
-    Lock status determines whether a given environment dependency will be installed from the
-    lockfile using the Poetry backend, or whether this plugin will skip it and allow it to be
-    installed using the default pip-based backend (an unlocked dependency).
-
-    .. note:: A locked dependency must follow a required format. To avoid reinventing the wheel
-              (no pun intended) this module does not have any infrastructure for parsing PEP-508
-              version specifiers, and so requires locked dependencies to be specified with no
-              version (the installed version being taken from the lockfile). If a dependency is
-              specified as locked and its name is also a PEP-508 string then an error will be
-              raised.
-    """
-
-    reporter.verbosity1(
-        f"{constants.REPORTER_PREFIX} sorting {len(venv.envconfig.deps)} env dependencies by lock requirement"
-    )
-    unlocked_deps = []
-    locked_deps = []
-
-    for dep in venv.envconfig.deps:
-        if venv.envconfig.require_locked_deps:
-            reporter.verbosity1(
-                f"{constants.REPORTER_PREFIX} lock required for env, treating '{dep.name}' as locked env dependency"
-            )
-            dep.name = dep.name.replace(constants.MAGIC_SUFFIX_MARKER, "")
-            locked_deps.append(dep)
-        else:
-            if dep.name.endswith(constants.MAGIC_SUFFIX_MARKER):
-                reporter.verbosity1(
-                    f"{constants.REPORTER_PREFIX} specification includes marker '{constants.MAGIC_SUFFIX_MARKER}', treating '{dep.name}' as locked env dependency"
-                )
-                dep.name = dep.name.replace(constants.MAGIC_SUFFIX_MARKER, "")
-                locked_deps.append(dep)
-            else:
-                reporter.verbosity1(
-                    f"{constants.REPORTER_PREFIX} specification does not include marker '{constants.MAGIC_SUFFIX_MARKER}', treating '{dep.name}' as unlocked env dependency"
-                )
-                unlocked_deps.append(dep)
-
-    reporter.verbosity1(
-        f"{constants.REPORTER_PREFIX} identified {len(locked_deps)} locked env dependencies: {[item.name for item in locked_deps]}"
-    )
-    reporter.verbosity1(
-        f"{constants.REPORTER_PREFIX} identified {len(unlocked_deps)} unlocked env dependencies: {[item.name for item in unlocked_deps]}"
-    )
-
-    return SortedEnvDeps(locked_deps=locked_deps, unlocked_deps=unlocked_deps)
 
 
 def install_to_venv(


### PR DESCRIPTION
These changes let the process Tox uses for determining whether an environment's dependencies have changed properly handle that determination. Now an environment will only be automatically recreated when the unlocked dependencies are changed. This does not affect explicitly recreating an environment.

One key drawback to this change is that the automatic recreate determination function Tox uses will not be accurate for locked dependencies. So even when the `locked_deps` config option is changed, the environment will not be automatically recated.

This is an API breaking change, as it requires modifications to any `tox.ini` file that was written to use an older version of the plugin.

* Add new config option `locked_deps` which replaces custom processing and runtime modification of the `deps` config option
* Remove plumbing previously necessary to make above work

Fixes #18 