### PR TITLE
Fix automated CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python.version }}
-      - name: Install tox
-        run: pip install "tox>=3.20.0,<3.21.0" --upgrade
+      - name: Install project
+        run: pip install .
       - name: Run tests via ${{ matrix.python.toxenv }}
         run: tox -e ${{ matrix.python.toxenv }}
   Check:
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - name: Install tox requirements
-        run: pip install "tox>=3.20.0,<3.21.0" --upgrade
+      - name: Install project
+        run: pip install .
       - name: Run meta checks
         run: tox -e static -e static-tests -e security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,5 +52,5 @@ toml = "^0.10.1"
 tox = "^3.20.0"
 
 [build-system]
-requires = ["poetry>=1.0.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
* Update pyproject to use poetry-core for PEP-517 builds
* Update CI definition to properly install current version of the plugin when running CI