### PR TITLE
Beta > Alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A plugin for [Tox](https://tox.readthedocs.io/en/latest/) that allows test environment
 dependencies to be installed using [Poetry](https://python-poetry.org/) from its lockfile.
 
-⚠️ **This project is alpha software and should not be used in production environments** ⚠️
+⚠️ **This project is beta software and is under active development** ⚠️
 
 [![ci-status](https://github.com/enpaul/tox-poetry-installer/workflows/CI/badge.svg?event=push)](https://github.com/enpaul/tox-poetry-installer/actions)
 [![pypi-version](https://img.shields.io/pypi/v/tox-poetry-installer)](https://pypi.org/project/tox-poetry-installer/)
@@ -531,10 +531,10 @@ releases on PyPI.
 
 ## Roadmap
 
-This project is under active development and is classified as alpha software, not yet ready
-for usage in production environments.
+This project is under active development and is classified as beta software, ready for
+production environments on a provisional basis only.
 
-* Beta classification will be assigned when the initial feature set is finalized
+* Beta classification was assigned with [v0.6.0](https://github.com/enpaul/tox-poetry-installer/releases/tag/0.6.0)
 * Stable classification will be assigned when the test suite covers an acceptable number of
   use cases
 

--- a/README.md
+++ b/README.md
@@ -479,8 +479,10 @@ the [`--require-poetry`](#--require-poetry) option.
 
 ## Developing
 
-This project requires a developer to have Poetry version 1.0+ installed on their workstation, see
+This project requires Poetry version 1.0+ on the development workstation, see
 the [installation instructions here](https://python-poetry.org/docs/#installation).
+
+Local environment setup instructions:
 
 ```bash
 # Clone the repository...
@@ -491,7 +493,7 @@ git clone git@github.com:enpaul/tox-poetry-installer.git
 
 # Create a the local project virtual environment and install dependencies
 cd tox-poetry-installer
-poetry install
+poetry install -E poetry
 
 # Install pre-commit hooks
 poetry run pre-commit install
@@ -500,11 +502,18 @@ poetry run pre-commit install
 poetry run tox
 ```
 
+**NOTE:** Because the pre-commit hooks require dependencies in the Poetry environment it
+is recommend to [launch an environment shell](https://python-poetry.org/docs/cli/#shell)
+when developing the project. Alternatively, many `git` commands will need to be run from
+outside of the environment shell by prefacing the command with
+[`poetry run`](https://python-poetry.org/docs/cli/#run).
+
 
 ## Contributing
 
 All project contributors and participants are expected to adhere to the
-[Contributor Covenant Code of Conduct, Version 2](CODE_OF_CONDUCT.md).
+[Contributor Covenant Code of Conduct, v2](CODE_OF_CONDUCT.md)
+([external link](https://www.contributor-covenant.org/version/2/0/code_of_conduct/)).
 
 The `devel` branch has the latest (potentially unstable) changes. The
 [tagged versions](https://github.com/enpaul/tox-poetry-installer/releases) correspond to the
@@ -537,24 +546,25 @@ for usage in production environments.
       Tox configuration option ([#4](https://github.com/enpaul/tox-poetry-installer/issues/4))
 - [X] Add per-environment Tox configuration option to fall back to default installation
       backend.
-- [ ] Add warnings when an unsupported Tox configuration option is detected while using the
-      Poetry backend. ([#5](https://github.com/enpaul/tox-poetry-installer/issues/5))
+- [ ] ~Add warnings when an unsupported Tox configuration option is detected while using the
+      Poetry backend. ([#5](https://github.com/enpaul/tox-poetry-installer/issues/5))~
 - [X] Add trivial tests to ensure the project metadata is consistent between the pyproject.toml
       and the module constants.
 - [X] Update to use [poetry-core](https://github.com/python-poetry/poetry-core) and
       improve robustness of the Tox and Poetry module imports
       to avoid potentially breaking API changes in upstream packages. ([#2](https://github.com/enpaul/tox-poetry-installer/issues/2))
-- [ ] Find and implement a way to mitigate the [UNSAFE_DEPENDENCIES issue](https://github.com/python-poetry/poetry/issues/1584) in Poetry.
-      ([#6](https://github.com/enpaul/tox-poetry-installer/issues/6))
-- [ ] Fix logging to make proper use of Tox's logging reporter infrastructure ([#3](https://github.com/enpaul/tox-poetry-installer/issues/3))
+- [ ] ~Find and implement a way to mitigate the [UNSAFE_DEPENDENCIES issue](https://github.com/python-poetry/poetry/issues/1584) in Poetry.
+      ([#6](https://github.com/enpaul/tox-poetry-installer/issues/6))~
+- [X] Fix logging to make proper use of Tox's logging reporter infrastructure ([#3](https://github.com/enpaul/tox-poetry-installer/issues/3))
 - [X] Add configuration option for installing all dev-dependencies to a testenv ([#14](https://github.com/enpaul/tox-poetry-installer/issues/14))
 
 ### Path to Stable
 
 Everything in Beta plus...
 
-- [ ] Add tests for each feature version of Tox between 2.3 and 3.20
-- [ ] Add tests for Python-3.6, 3.7, and 3.8
+- [ ] Add comprehensive unit tests
+- [ ] Add tests for each feature version of Tox between 3.0 and 3.20
+- [ ] Add tests for Python-3.6, 3.7, 3.8, and 3.9
 - [X] Add Github Actions based CI
 - [ ] Add CI for CPython, PyPy, and Conda
 - [ ] Add CI for Linux and Windows

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ differences in the dependency graph of the active development environment (the o
 by Poetry) and the automated test environment(s) created by Tox.
 
 To learn more about the problems this plugin aims to solve jump ahead to
-[What problems does this solve?](#what-problems-does-this-solve).
+[What problems does this solve?](#why-would-i-use-this).
 Otherwise keep reading to get started.
 
 ### Install
@@ -158,7 +158,7 @@ description = Some very cool tests
 install_dev_deps = true
 ```
 
-See the [Plugin Usage](#plugin-usage) section for more details on available
+See the [Reference](#reference) section for more details on available
 configuration options and the [Advanced Usage](#advanced-usage) section for some
 unusual use cases.
 
@@ -166,11 +166,10 @@ unusual use cases.
 
 **The Problem**
 
-By default Tox uses [Pip](https://docs.python.org/3/tutorial/venv.html) to install the
-[PEP-508](https://www.python.org/dev/peps/pep-0508/) compliant dependencies to a test
-environment. This plugin extends the default Tox dependency installation behavior to
-support installing dependencies using a Poetry-based installation method that makes use
-of the dependency metadata from Poetry's lockfile.
+By default Tox uses Pip to install the [PEP-508](https://www.python.org/dev/peps/pep-0508/)
+compliant dependencies to a test environment. This plugin extends the default Tox
+dependency installation behavior to support installing dependencies using a Poetry-based
+installation method that makes use of the dependency metadata from Poetry's lockfile.
 
 Environment dependencies for a Tox environment are usually specified in PEP-508 format, like
 the below example:
@@ -292,8 +291,8 @@ hook.
 
 Whether all Poetry dev-dependencies should be installed to the environment. If `true`
 then all dependencies specified in the
-[`dev-dependencies` section](https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies)
-of `pyproject.toml` will be installed automatically.
+[`dev-dependencies`](https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies)
+section of `pyproject.toml` will be installed automatically.
 
 ### Command-line Arguments
 
@@ -306,7 +305,7 @@ Indicates that Poetry is expected to be available to Tox and, if it is not, then
 run should fail. If provided and the `poetry` package is not installed to the same
 environment as the `tox` package then Tox will fail.
 
-**NOTE:** See [Advanced Usage](installing-alongside-an-existing-poetry-installation)
+**NOTE:** See [Advanced Usage](#installing-alongside-an-existing-poetry-installation)
 for more information.
 
 ### Errors
@@ -330,7 +329,7 @@ lockfile with the `pyproject.toml` run one of
   * Install Poetry: ensure that `poetry` is installed to the same environment as `tox`.
   * Skip running the plugin: remove the `--require-poetry` flag from the runtime options.
 
-**NOTE:** See [Advanced Usage](installing-alongside-an-existing-poetry-installation)
+**NOTE:** See [Advanced Usage](#installing-alongside-an-existing-poetry-installation)
 for more information.
 
 #### Locked Dependency Version Conflict Error
@@ -352,9 +351,8 @@ for more information.
 * **Cause:** Indicates that a dependency specified in the [`locked_deps`](#locked_deps)
   configuration option in `tox.ini` could not be found in the Poetry lockfile.
 * **Resolution options:**
-  * Add the dependency to the lockfile: run `poetry add <dependency>`;
-    see [the Poetry documentation](https://python-poetry.org/docs/cli/#add) for more
-    information.
+  * Add the dependency to the lockfile: run
+    [`poetry add <dependency>`](https://python-poetry.org/docs/cli/#add).
   * Do not install the dependency: remove the item from the `locked_deps` list in
     `tox.ini`.
 
@@ -366,9 +364,9 @@ for more information.
   `pyproject.toml`
 * **Resolution options:**
   * Configure the extra: add a section for the named extra to the
-    [`extras` section of `pyproject.toml`](https://python-poetry.org/docs/pyproject/#extras)
-    and optionally assign dependencies to the named extra using the
-    [`--optional` dependency setting](https://python-poetry.org/docs/cli/#options_3).
+    [`extras`](https://python-poetry.org/docs/pyproject/#extras) section of
+    `pyproject.toml` and optionally assign dependencies to the named extra using the
+    [`--optional`](https://python-poetry.org/docs/cli/#options_3) dependency setting.
   * Remove the extra: remove the item from the `extras` list in `tox.ini`.
 
 #### Locked Dependencies Required Error
@@ -434,10 +432,10 @@ are four packages classified as "unsafe" by Poetry and excluded from the lockfil
 When one of these packages is encountered by the plugin a warning will be logged and
 _**the package will not be installed to the environment**_. If the unsafe package
 is required for the environment then it will need to be specified as an unlocked
-dependency using the [`deps`](https://github.com/python-poetry/poetry/releases/tag/1.1.4)
+dependency using the [`deps`](https://tox.readthedocs.io/en/latest/config.html#conf-deps)
 configuration option in `tox.ini`, ideally with an exact pinned version.
 
-* The set of packages excluded from the Poetry lockfile can be found at
+* The set of packages excluded from the Poetry lockfile can be found in
   [`poetry.puzzle.provider.Provider.UNSAFE_DEPENDENCIES`](https://github.com/python-poetry/poetry/blob/master/poetry/puzzle/provider.py)
 * There is an ongoing discussion of Poetry's handling of these packages at
   [python-poetry/poetry#1584](https://github.com/python-poetry/poetry/issues/1584)

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ dependencies to be installed using [Poetry](https://python-poetry.org/) from its
 Related resources:
 * [Poetry Python Project Manager](https://python-poetry.org/)
 * [Tox Automation Project](https://tox.readthedocs.io/en/latest/)
+* [Other Tox plugins](https://tox.readthedocs.io/en/latest/plugins.html)
+
+Similar projects:
 * [Poetry Dev-Dependencies Tox Plugin](https://github.com/sinoroc/tox-poetry-dev-dependencies)
 * [Poetry Tox Plugin](https://github.com/tkukushkin/tox-poetry)
-* [Other Tox plugins](https://tox.readthedocs.io/en/latest/plugins.html)
 
 
 ## Installation
@@ -491,7 +493,7 @@ releases on PyPI.
 * To report a bug, request a feature, or ask for assistance, please
   [open an issue on the Github repository](https://github.com/enpaul/tox-poetry-installer/issues/new).
 * To report a security concern or code of conduct violation, please contact the project author
-  directly at **ethan dot paul at enp dot one**.
+  directly at **‌me [at‌] enp dot‎ ‌one**.
 * To submit an update, please
   [fork the repository](https://docs.github.com/en/enterprise/2.20/user/github/getting-started-with-github/fork-a-repo)
   and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ include = [
 keywords = ["tox", "poetry", "plugin"]
 readme = "README.md"
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Environment :: Plugins",
   "Framework :: tox",
   "Intended Audience :: Developers",


### PR DESCRIPTION
* Overhaul documentation
  * Add more useful documentation of error states and potential solutions
  * Add clearer documentation of plugin-provided configuration options
  * Add embeded links for easier navigation around the readme
  * Add download badge
  * Add instructions for handling Poetry's unsafe dependencies (Fixes #6)
  * Add documentation of unsupported Tox configuration options (Fixes #5)
  * Fix misc problems with the developer, contributor, and roadmap docs that came from not being updated in a while
* Update PyPI project classification from `3 - Alpha` to `4 - Beta`
