### PR TITLE
Fix unsafe dependency handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tox-poetry-installer"
-version = "0.6.0"
+version = "0.6.1"
 license = "MIT"
 authors = ["Ethan Paul <24588726+enpaul@users.noreply.github.com>"]
 description = "Tox plugin to install Tox environment dependencies using the Poetry backend and lockfile"

--- a/tox_poetry_installer/__about__.py
+++ b/tox_poetry_installer/__about__.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-docstring
 __title__ = "tox-poetry-installer"
 __summary__ = "Tox plugin to install Tox environment dependencies using the Poetry backend and lockfile"
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __url__ = "https://github.com/enpaul/tox-poetry-installer/"
 __license__ = "MIT"
 __authors__ = ["Ethan Paul <24588726+enpaul@users.noreply.github.com>"]

--- a/tox_poetry_installer/utilities.py
+++ b/tox_poetry_installer/utilities.py
@@ -67,7 +67,7 @@ def find_transients(packages: PackageMap, dependency_name: str) -> Set[PoetryPac
 
         if name in _poetry.Provider.UNSAFE_PACKAGES:
             reporter.warning(
-                f"{constants.REPORTER_PREFIX} Installing package '{name}' using Poetry is not supported; skipping installation of package '{name}'"
+                f"{constants.REPORTER_PREFIX} Installing package '{name}' using Poetry is not supported and will be skipped"
             )
             reporter.verbosity2(
                 f"{constants.REPORTER_PREFIX} Skip {name}: designated unsafe by Poetry"
@@ -110,6 +110,12 @@ def find_transients(packages: PackageMap, dependency_name: str) -> Set[PoetryPac
             packages[dependency_name].name, searched
         )
     except KeyError:
+        if dependency_name in _poetry.Provider.UNSAFE_PACKAGES:
+            reporter.warning(
+                f"{constants.REPORTER_PREFIX} Installing package '{dependency_name}' using Poetry is not supported and will be skipped"
+            )
+            return set()
+
         if any(
             delimiter in dependency_name
             for delimiter in constants.PEP508_VERSION_DELIMITERS
@@ -117,6 +123,7 @@ def find_transients(packages: PackageMap, dependency_name: str) -> Set[PoetryPac
             raise exceptions.LockedDepVersionConflictError(
                 f"Locked dependency '{dependency_name}' cannot include version specifier"
             ) from None
+
         raise exceptions.LockedDepNotFoundError(
             f"No version of locked dependency '{dependency_name}' found in the project lockfile"
         ) from None

--- a/tox_poetry_installer/utilities.py
+++ b/tox_poetry_installer/utilities.py
@@ -63,8 +63,6 @@ def find_transients(packages: PackageMap, dependency_name: str) -> Set[PoetryPac
     from tox_poetry_installer import _poetry
 
     def find_deps_of_deps(name: str, searched: Set[str]) -> PackageMap:
-        package = packages[name]
-        transients: PackageMap = {}
         searched.add(name)
 
         if name in _poetry.Provider.UNSAFE_PACKAGES:
@@ -72,9 +70,15 @@ def find_transients(packages: PackageMap, dependency_name: str) -> Set[PoetryPac
                 f"{constants.REPORTER_PREFIX} Installing package '{name}' using Poetry is not supported; skipping installation of package '{name}'"
             )
             reporter.verbosity2(
-                f"{constants.REPORTER_PREFIX} Skip {package}: designated unsafe by Poetry"
+                f"{constants.REPORTER_PREFIX} Skip {name}: designated unsafe by Poetry"
             )
-        elif not package.python_constraint.allows(constants.PLATFORM_VERSION):
+
+            return dict()
+
+        transients: PackageMap = {}
+        package = packages[name]
+
+        if not package.python_constraint.allows(constants.PLATFORM_VERSION):
             reporter.verbosity2(
                 f"{constants.REPORTER_PREFIX} Skip {package}: incompatible Python requirement '{package.python_constraint}' for current version '{constants.PLATFORM_VERSION}'"
             )

--- a/tox_poetry_installer/utilities.py
+++ b/tox_poetry_installer/utilities.py
@@ -72,7 +72,6 @@ def find_transients(packages: PackageMap, dependency_name: str) -> Set[PoetryPac
             reporter.verbosity2(
                 f"{constants.REPORTER_PREFIX} Skip {name}: designated unsafe by Poetry"
             )
-
             return dict()
 
         transients: PackageMap = {}
@@ -87,11 +86,20 @@ def find_transients(packages: PackageMap, dependency_name: str) -> Set[PoetryPac
                 f"{constants.REPORTER_PREFIX} Skip {package}: incompatible platform requirement '{package.platform}' for current platform '{sys.platform}'"
             )
         else:
-            reporter.verbosity2(f"{constants.REPORTER_PREFIX} Include {package}")
+            reporter.verbosity2(
+                f"{constants.REPORTER_PREFIX} Including {package} for installation"
+            )
             transients[name] = package
-            for dep in package.requires:
+            for index, dep in enumerate(package.requires):
+                reporter.verbosity2(
+                    f"{constants.REPORTER_PREFIX} Processing dependency {index + 1}/{len(package.requires)} for {package}: {dep.name}"
+                )
                 if dep.name not in searched:
                     transients.update(find_deps_of_deps(dep.name, searched))
+                else:
+                    reporter.verbosity2(
+                        f"{constants.REPORTER_PREFIX} Package with name '{dep.name}' has already been processed, skipping"
+                    )
 
         return transients
 


### PR DESCRIPTION
* Fix a regression causing handling of Poetry's unsafe dependencies to fail with an unclear error
* Improve logging around transient dependency processing

Fixes #33 