### PR TITLE
Add three state boolean logic for install_project_deps config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tox-poetry-installer"
-version = "0.8.0"
+version = "0.8.1"
 license = "MIT"
 authors = ["Ethan Paul <24588726+enpaul@users.noreply.github.com>"]
 description = "A plugin for Tox that lets you install test environment dependencies from the Poetry lockfile"

--- a/tox_poetry_installer/__about__.py
+++ b/tox_poetry_installer/__about__.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-docstring
 __title__ = "tox-poetry-installer"
 __summary__ = "A plugin for Tox that lets you install test environment dependencies from the Poetry lockfile"
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 __url__ = "https://github.com/enpaul/tox-poetry-installer/"
 __license__ = "MIT"
 __authors__ = ["Ethan Paul <24588726+enpaul@users.noreply.github.com>"]


### PR DESCRIPTION
Fixes #61 

This is a workaround patch for a more severe design problem. See the docstring in `_postprocess_install_project_deps()` function for more information.