### PR TITLE
Add logging for package installation completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 See also: [Github Release Page](https://github.com/enpaul/tox-poetry-installer/releases).
 
+## Version 0.8.2
+
+View this release on:
+[Github](https://github.com/enpaul/tox-poetry-installer/releases/tag/0.8.2),
+[PyPI](https://pypi.org/project/tox-poetry-installer/0.8.2/)
+
+- Improve debug-level logging for package installation, and time how long installing each
+  package takes. Contributed by [Rebecca
+  Turner](https://github.com/9999years).
+
 ## Version 0.8.1
 
 View this release on:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tox-poetry-installer"
-version = "0.8.1"
+version = "0.8.2"
 license = "MIT"
 authors = ["Ethan Paul <24588726+enpaul@users.noreply.github.com>"]
 description = "A plugin for Tox that lets you install test environment dependencies from the Poetry lockfile"

--- a/tox_poetry_installer/__about__.py
+++ b/tox_poetry_installer/__about__.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-docstring
 __title__ = "tox-poetry-installer"
 __summary__ = "A plugin for Tox that lets you install test environment dependencies from the Poetry lockfile"
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 __url__ = "https://github.com/enpaul/tox-poetry-installer/"
 __license__ = "MIT"
 __authors__ = ["Ethan Paul <24588726+enpaul@users.noreply.github.com>"]

--- a/tox_poetry_installer/installer.py
+++ b/tox_poetry_installer/installer.py
@@ -5,6 +5,7 @@
 import concurrent.futures
 import contextlib
 import typing
+from datetime import datetime
 from typing import Sequence
 from typing import Set
 
@@ -46,6 +47,13 @@ def install(
 
     installed: Set[PoetryPackage] = set()
 
+    def logged_install(dependency: PoetryPackage) -> None:
+        start = datetime.now()
+        logger.debug(f"Installing {dependency}")
+        pip.install(dependency)
+        end = datetime.now()
+        logger.debug(f"Finished installing {dependency} in {end - start}")
+
     @contextlib.contextmanager
     def _optional_parallelize():
         """A bit of cheat, really
@@ -66,8 +74,8 @@ def install(
         for dependency in packages:
             if dependency not in installed:
                 installed.add(dependency)
-                logger.debug(f"Installing {dependency}")
-                executor(pip.install, dependency)
+                logger.debug(f"Queuing {dependency}")
+                executor(logged_install, dependency)
             else:
                 logger.debug(f"Skipping {dependency}, already installed")
         logger.debug("Waiting for installs to finish...")


### PR DESCRIPTION
Currently, tox-poetry-installer logs when it submits a dependency to the (possibly-parallel) executor for installation, but not when the installation is finished; this commit adds a log message when the installation actually starts (in contrast with when the job is queued) and a log message when the installation completes, along with the wall time it took.

Rationale: I've noticed in some cases when running under Python 3.10 packages take much longer to install -- this logging should help pinpoint culprits.