### PR TITLE
Add official support for Python 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,8 @@ jobs:
             toxenv: py39
           - version: "3.10"
             toxenv: py310
+          - version: "3.11"
+            toxenv: py311
       fail-fast: true
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310, static, static-tests, security
+envlist = py37, py38, py39, py310, py311, static, static-tests, security
 isolated_build = true
 skip_missing_interpreters = true
 


### PR DESCRIPTION
* Add pypi classifier for py3.11
* Update CI to test py3.11

This will fail the security check CI due to python-poetry/poetry-plugin-export#176