### PR TITLE
Ensure exceptions which occur during install are propagated

### DIFF
--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -65,9 +65,11 @@ def test_parallelization(mock_venv, mock_poetry_factory):
 def test_propagates_exceptions_during_installation(
     mock_venv, mock_poetry_factory, num_threads
 ):
-    # Assert that an exception which occurs during installation is properly raised.
-    # Regression test for https://github.com/enpaul/tox-poetry-installer/issues/86
-    from tox_poetry_installer import _poetry
+    """Assert that an exception which occurs during installation is properly raised.
+
+    Regression test for https://github.com/enpaul/tox-poetry-installer/issues/86
+    """
+    from tox_poetry_installer import _poetry  # pylint: disable=import-outside-toplevel
 
     poetry = Factory().create_poetry(None)
     packages: utilities.PackageMap = {

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -8,7 +8,6 @@ from poetry.factory import Factory
 
 from .fixtures import mock_poetry_factory
 from .fixtures import mock_venv
-from tox_poetry_installer import _poetry
 from tox_poetry_installer import installer
 from tox_poetry_installer import utilities
 
@@ -68,6 +67,8 @@ def test_propagates_exceptions_during_installation(
 ):
     # Assert that an exception which occurs during installation is properly raised.
     # Regression test for https://github.com/enpaul/tox-poetry-installer/issues/86
+    from tox_poetry_installer import _poetry
+
     poetry = Factory().create_poetry(None)
     packages: utilities.PackageMap = {
         item.name: item for item in poetry.locker.locked_repository().packages

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,11 +1,14 @@
 # pylint: disable=missing-module-docstring, redefined-outer-name, unused-argument, wrong-import-order, unused-import
 import time
+from unittest import mock
 
+import pytest
 import tox.venv
 from poetry.factory import Factory
 
 from .fixtures import mock_poetry_factory
 from .fixtures import mock_venv
+from tox_poetry_installer import _poetry
 from tox_poetry_installer import installer
 from tox_poetry_installer import utilities
 
@@ -57,3 +60,28 @@ def test_parallelization(mock_venv, mock_poetry_factory):
     assert round(parallel * 5) == round(sequential)
     assert round(sequential) == len(set(to_install))
     assert round(parallel * 5) == len(set(to_install))
+
+
+@pytest.mark.parametrize("num_threads", (0, 8))
+def test_propagates_exceptions_during_installation(
+    mock_venv, mock_poetry_factory, num_threads
+):
+    # Assert that an exception which occurs during installation is properly raised.
+    # Regression test for https://github.com/enpaul/tox-poetry-installer/issues/86
+    poetry = Factory().create_poetry(None)
+    packages: utilities.PackageMap = {
+        item.name: item for item in poetry.locker.locked_repository().packages
+    }
+    to_install = [packages["toml"]]
+    venv = tox.venv.VirtualEnv()
+    fake_exception = ValueError("my testing exception")
+
+    with mock.patch.object(
+        _poetry,
+        "PipInstaller",
+        **{"return_value.install.side_effect": fake_exception},
+    ):
+        with pytest.raises(ValueError) as exc_info:
+            installer.install(poetry, venv, to_install, num_threads)
+
+    assert exc_info.value is fake_exception

--- a/tox_poetry_installer/installer.py
+++ b/tox_poetry_installer/installer.py
@@ -71,11 +71,20 @@ def install(
             yield lambda func, arg: func(arg)
 
     with _optional_parallelize() as executor:
+        futures = []
         for dependency in packages:
             if dependency not in installed:
                 installed.add(dependency)
                 logger.debug(f"Queuing {dependency}")
-                executor(logged_install, dependency)
+                future = executor(logged_install, dependency)
+                if future is not None:
+                    futures.append(future)
             else:
                 logger.debug(f"Skipping {dependency}, already installed")
         logger.debug("Waiting for installs to finish...")
+
+        for future in concurrent.futures.as_completed(futures):
+            # Don't actually care about the return value, just waiting on the
+            # future to ensure any exceptions that were raised in the called
+            # function are propagated.
+            future.result()


### PR DESCRIPTION
Fixes #86 

I've tested this against @benbariteau's test repo (https://github.com/benbariteau/tox-poetry-installer-parallel-install-bug-repro) and it now produces an error during install when installing with multiple threads, just like it does when installing without parallelization:

```
$ rm -rf .tox/py310 && tox -e py310
py310 create: /nail/home/ckuehl/proj/tox-poetry-installer-parallel-install-bug-repro/.tox/py310
py310 tox-poetry-installer: Installing 1 dependencies from Poetry lock file (using 10 threads)
________________________________________________________________________________________________________________________________________________________________________________ summary _________________________________________________________________________________________________________________________________________________________________________________
  py310: commands succeeded
  congratulations :)
Traceback (most recent call last):
  File "/nail/home/ckuehl/proj/tox-poetry-installer-parallel-install-bug-repro/.tox/.tox/lib/python3.7/site-packages/poetry/utils/env.py", line 1537, in _run
    command, stderr=subprocess.STDOUT, env=env, **kwargs
  File "/usr/lib/python3.7/subprocess.py", line 411, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.7/subprocess.py", line 512, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/nail/home/ckuehl/proj/tox-poetry-installer-parallel-install-bug-repro/.tox/py310/bin/python', '-m', 'pip', 'install', '--no-deps', '--no-input', '-r', '/tmp/greenlet-1.0.0k7m9_iqnreqs.txt']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  [...]
poetry.utils.env.EnvCommandError: Command ['/nail/home/ckuehl/proj/tox-poetry-installer-parallel-install-bug-repro/.tox/py310/bin/python', '-m', 'pip', 'install', '--no-deps', '--no-input', '-r', '/tmp/greenlet-1.0.0k7m9_iqnreqs.txt'] errored with the following return code 1, and output:
Looking in indexes: http://169.254.255.254:20641/jammy/simple/
Collecting greenlet==1.0.0
  Using cached http://169.254.255.254:20641/f/jammy/greenlet-1.0.0.tar.gz (84 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Building wheels for collected packages: greenlet
  Building wheel for greenlet (setup.py): started
  Building wheel for greenlet (setup.py): finished with status 'error'
  error: subprocess-exited-with-error

  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
[...]

note: This is an issue with the package mentioned above, not pip.
hint: See above for output from the failure.
```

The tox command exits nonzero as expected.

I also added a regression test as part of this PR which is passing. If I undo my changes to `tox_poetry_installer/installer.py`, then the regression test passes in the case without parallelization and fails with parallelization:

```
$ .tox/py310/bin/pytest -k test_propagates_exceptions tests
================================================================================= test session starts ==================================================================================
platform linux -- Python 3.10.6, pytest-7.2.2, pluggy-1.0.0
rootdir: /nail/home/ckuehl/proj/tox-poetry-installer
plugins: cov-4.0.0
collected 9 items / 7 deselected / 2 selected

tests/test_installer.py .F                                                                                                                                                       [100%]

======================================================================================= FAILURES =======================================================================================
__________________________________________________________________ test_propagates_exceptions_during_installation[8] ___________________________________________________________________

mock_venv = None, mock_poetry_factory = None, num_threads = 8

    @pytest.mark.parametrize("num_threads", (0, 8))
    def test_propagates_exceptions_during_installation(mock_venv, mock_poetry_factory, num_threads):
        # Assert that an exception which occurs during installation is properly raised.
        # Regression test for https://github.com/enpaul/tox-poetry-installer/issues/86
        poetry = Factory().create_poetry(None)
        packages: utilities.PackageMap = {
            item.name: item for item in poetry.locker.locked_repository().packages
        }
        to_install = [packages["toml"]]
        venv = tox.venv.VirtualEnv()
        fake_exception = ValueError("my testing exception")

        with mock.patch.object(
            _poetry,
            "PipInstaller",
            **{"return_value.install.side_effect": fake_exception},
        ):
>           with pytest.raises(ValueError) as exc_info:
E           Failed: DID NOT RAISE <class 'ValueError'>

tests/test_installer.py:82: Failed
=============================================================================== short test summary info ================================================================================
FAILED tests/test_installer.py::test_propagates_exceptions_during_installation[8] - Failed: DID NOT RAISE <class 'ValueError'>
====================================================================== 1 failed, 1 passed, 7 deselected in 0.42s =======================================================================
```

Note: I had some trouble getting all of the linters running locally, so I might need to iterate on this PR a bit in case CI doesn't pass.